### PR TITLE
fix: handle both reminder and deadline pusher notifications

### DIFF
--- a/src/layouts/App.jsx
+++ b/src/layouts/App.jsx
@@ -15,36 +15,27 @@ const App = () => {
         encrypted: true
       });
       const channel = pusher.subscribe(`notifications-${user._id}`);
-      channel.bind("project-deadline", data => {
-        if (data.type === "reminder") {
-          if (data.task !== undefined) {
-            //send notification for task reminder
-            let title = `Rappel - ${data.note.title}`;
-            let message = data.task.title;
-            let url = `${process.env.PUBLIC_URL}/notes/${data.note._id}`;
-
+      channel.bind("project", data => {
+        for (const notification of data.notifications) {
+          let title = "";
+          const url = `${process.env.PUBLIC_URL}/notes/${notification.note._id}`;
+          let message = "";
+          // Handle reminder notifications
+          if (data.type === "reminder") {
+            title = `Reminder - ${notification.note.title}`;
+            message = notification.task.title;
             NotificationService.send(title, message, url);
-          } else if (data.note !== undefined) {
-            //send notification for note reminder
-            let title = `Reminder - ${data.note.title}`;
-            let message = "The deadline for your note is arrived";
-            let url = `${process.env.PUBLIC_URL}/notes/${data.note._id}`;
-
-            NotificationService.send(title, message, url);
+            continue;
           }
+
+          // Handle deadline notifications
+          title = `Deadline - ${notification.note.title}`;
+          message = notification.task
+            ? notification.task.title
+            : "The deadline for your note is today";
+
+          NotificationService.send(title, message, url);
         }
-        //add new type if needed
-        /*
-          Data is an array with objects looking like:
-          {
-            note: {_id: "5fbe718f5d783f001125aafd", template: "project", title: "My new project note"}
-            plannedDate: "2020-11-29T14:40:00.000Z"
-            task: {_id: "5fbe9453ae14c38653f29be3", isCompleted: false, template: "projectTask", title: "My task 1"}
-            type: "reminder"
-            _id: "5fc3b2a100046c00111f4338"
-          }
-          If the field 'task' is there, it means that this is a reminder or deadline for a task, otherwise, it is a deadline for a note
-        */
       });
     }
   }, []);


### PR DESCRIPTION
How did it worked before??? data was an array, not an object 😟 I changed it to an object for this PR but it shouldn't have worked before... it's weird 😅
Anyway I hope I didn't break it with this PR 🙏
Also I wanted to try react-intl but it is not accessible in the App and I didn't know how to update the language depending on the language sent with the notifications (data.language) so I left static messages